### PR TITLE
Refactor fsnotify into watchers/FsWatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Ignore built artifact
 fits
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/main.go
+++ b/main.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
+
 	"github.com/sebastianappler/fits/watchers"
-	"github.com/fsnotify/fsnotify"
 	"github.com/pelletier/go-toml"
 )
 
@@ -32,43 +31,10 @@ func main() {
 		toPath = GetFullPath(config.Get("to.path").(string))
 	}
 
-	fmt.Printf("Transfering from %#v ", fromPath)
-	fmt.Printf("to %#v.\n", toPath)
-
-	watcher, err := fsnotify.NewWatcher()
+	err = watchers.Watch(fromPath, toPath)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	defer watcher.Close()
-
-	done := make(chan bool)
-
-	go func() {
-		for {
-			select {
-			case event := <-watcher.Events:
-				fmt.Println("Event", event)
-
-				if event.Op&fsnotify.Create == fsnotify.Create {
-					moveFrom := event.Name
-					moveTo := path.Join(toPath, filepath.Base(event.Name))
-					err := watchers.MoveFile(moveFrom, moveTo)
-					if err != nil {
-						fmt.Println(err)
-					}
-				}
-
-			case err := <-watcher.Errors:
-				log.Fatal(err)
-			}
-		}
-	}()
-
-	if err := watcher.Add(fromPath); err != nil {
-		log.Fatal(err)
-	}
-	<-done
 }
 
 func GetFullPath(path string) string {
@@ -86,3 +52,4 @@ func GetFullPath(path string) string {
 
 	return fullPath
 }
+

--- a/watchers/FsWatcher.go
+++ b/watchers/FsWatcher.go
@@ -1,0 +1,55 @@
+package watchers
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+type FsWatcher struct {
+	From string
+	To string
+}
+
+func MoveFile(from, to string) error {
+	in, err := os.Open(from)
+	if err != nil {
+		return fmt.Errorf("Couldn't open source file: %s", err)
+	}
+
+	out, err := os.Create(to)
+	if err != nil {
+		in.Close()
+		return fmt.Errorf("Couldn't open dest file: %s", err)
+	}
+
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	in.Close()
+	if err != nil {
+		return fmt.Errorf("Writing to output file failed: %s", err)
+	}
+
+	err = out.Sync()
+	if err != nil {
+		return fmt.Errorf("Sync error: %s", err)
+	}
+
+	si, err := os.Stat(from)
+	if err != nil {
+		return fmt.Errorf("Stat error: %s", err)
+	}
+
+	err = os.Chmod(to, si.Mode())
+	if err != nil {
+		return fmt.Errorf("Chmod error: %s", err)
+	}
+
+	err = os.Remove(from)
+	if err != nil {
+		return fmt.Errorf("Failed removing original file: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit will refactor the usage of `fsnotify`
into an own `watcher` package called `FsWatcher`